### PR TITLE
Properly load the formwidget value

### DIFF
--- a/formwidgets/Wysiwyg.php
+++ b/formwidgets/Wysiwyg.php
@@ -22,7 +22,7 @@ class Wysiwyg extends FormWidgetBase
     public function prepareVars()
     {
          $this->vars['name']      = $this->formField->getName();
-         $this->vars['value']     = $this->model->{$this->fieldName};
+         $this->vars['value']     = $this->getLoadValue();
          $this->vars['width']     = Settings::instance()->form_width;
          $this->vars['height']    = Settings::instance()->form_height;
          $this->vars['toolbar']   = Settings::instance()->toolbar;


### PR DESCRIPTION
This fixes a bug when attempting to use the widget on a nested field (i.e. inside of a JSONable column).